### PR TITLE
Add --allow-bias flag to control bias frame usage

### DIFF
--- a/ap_copy_master_to_blink/__main__.py
+++ b/ap_copy_master_to_blink/__main__.py
@@ -156,6 +156,13 @@ Examples:
         help="Enable debug logging",
     )
 
+    parser.add_argument(
+        "--allow-bias",
+        action="store_true",
+        help="Allow shorter darks with bias frames. "
+        "Default: only exact exposure match darks are copied.",
+    )
+
     args = parser.parse_args()
 
     # Setup logging
@@ -177,7 +184,11 @@ Examples:
 
     # Process blink directory
     stats = process_blink_directory(
-        library_dir, blink_dir, dry_run=args.dryrun, quiet=args.quiet
+        library_dir,
+        blink_dir,
+        dry_run=args.dryrun,
+        quiet=args.quiet,
+        allow_bias=args.allow_bias,
     )
 
     # Print summary

--- a/ap_copy_master_to_blink/copy_masters.py
+++ b/ap_copy_master_to_blink/copy_masters.py
@@ -187,6 +187,7 @@ def process_blink_directory(
     blink_dir: Path,
     dry_run: bool = False,
     quiet: bool = False,
+    allow_bias: bool = False,
 ) -> Dict[str, int]:
     """
     Main orchestration logic to copy masters to blink directories.
@@ -196,6 +197,8 @@ def process_blink_directory(
         blink_dir: Path to blink directory tree
         dry_run: If True, log actions but don't copy files
         quiet: Suppress progress output
+        allow_bias: If False, only exact exposure match darks are copied.
+                   If True, shorter exposure darks with bias are allowed.
 
     Returns:
         Dictionary with summary statistics:
@@ -292,7 +295,9 @@ def process_blink_directory(
         )
 
         # Find required masters
-        masters = determine_required_masters(library_dir, light_metadata)
+        masters = determine_required_masters(
+            library_dir, light_metadata, allow_bias=allow_bias
+        )
         dark = masters[TYPE_MASTER_DARK]
         bias = masters[TYPE_MASTER_BIAS]
         flat = masters[TYPE_MASTER_FLAT]

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -69,7 +69,7 @@ class TestMatching(unittest.TestCase):
 
     @patch("ap_copy_master_to_blink.matching.get_filtered_metadata")
     def test_find_matching_dark_shorter_exposure(self, mock_get_metadata):
-        """Test finding dark with shorter exposure (no exact match)."""
+        """Test finding dark with shorter exposure when bias allowed."""
         mock_get_metadata.return_value = {
             "/test/library/dark_120s.xisf": {
                 NORMALIZED_HEADER_EXPOSURESECONDS: "120",
@@ -81,7 +81,9 @@ class TestMatching(unittest.TestCase):
             },
         }
 
-        result = find_matching_dark(self.library_dir, self.light_metadata)
+        result = find_matching_dark(
+            self.library_dir, self.light_metadata, allow_bias=True
+        )
 
         self.assertIsNotNone(result)
         # Should pick longest dark < 300s (120s)


### PR DESCRIPTION
- Add --allow-bias CLI flag to control whether shorter darks with bias are acceptable (default: require exact exposure match)
- Update find_matching_dark to return None when allow_bias=False and no exact exposure match found
- Update determine_required_masters and process_blink_directory to accept allow_bias parameter
- Use named parameters for process_blink_directory call

Assisted-by: Claude Code (Claude Sonnet 4.5)