### PR TITLE
Add CRITICAL comments and tests to protect output order

### DIFF
--- a/ap_copy_master_to_blink/__main__.py
+++ b/ap_copy_master_to_blink/__main__.py
@@ -87,6 +87,11 @@ def print_summary(stats: Dict[str, int]) -> None:
         f"{plural(stats['date_count'], 'date')}, "
         f"{plural(stats['filter_count'], 'filter')})"
     )
+
+    # CRITICAL: Output order MUST be: Biases, Darks, Flats
+    # CRITICAL: Bias MUST ALWAYS be shown (even if 0 of 0)
+    # This order has regressed multiple times - DO NOT CHANGE without updating tests
+    # See test_print_summary_output_order() in tests/test_copy_masters.py
     print(
         f"Biases: {stats['biases_present']} of {stats['biases_needed']} | "
         f"{status_indicator(stats['biases_present'], stats['biases_needed'])}"


### PR DESCRIPTION
- Add CRITICAL comments documenting required output order: Biases, Darks, Flats
- Add CRITICAL comment that bias MUST ALWAYS be shown even when 0 of 0
- Add 4 unit tests to enforce output order and prevent regression
- Document that order has regressed multiple times and references tests

Assisted-by: Claude Code (Claude Sonnet 4.5)