### PR TITLE
Replace --allow-bias with --scale-dark flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/coverage.yml/badge.svg)](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/coverage.yml)
 [![Lint](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/lint.yml/badge.svg)](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/lint.yml)
 [![Format](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/format.yml/badge.svg)](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/format.yml)
+[![Type Check](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/typecheck.yml/badge.svg)](https://github.com/jewzaam/ap-copy-master-to-blink/actions/workflows/typecheck.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -43,12 +44,12 @@ Library searches read **actual FITS headers** from calibration files, not path s
 Priority matching (in order):
 
 1. **Exact exposure match**: Same camera, gain, offset, settemp, readoutmode, and exposure time
-2. **Shorter exposure + bias** (requires `--allow-bias`): If no exact match, find the longest dark exposure < light exposure
+2. **Shorter exposure + bias** (requires `--scale-dark`): If no exact match, find the longest dark exposure < light exposure
    - **Requires matching bias**: Will not use shorter dark without bias
-   - **Default behavior**: Without `--allow-bias`, only exact exposure match darks are copied
-3. **No match**: If no exact dark and no bias (or `--allow-bias` not specified), skip (logged as missing)
+   - **Default behavior**: Without `--scale-dark`, only exact exposure match darks are copied
+3. **No match**: If no exact dark and no bias (or `--scale-dark` not specified), skip (logged as missing)
 
-**Note**: By default, only exact exposure match darks are copied. Use `--allow-bias` to enable shorter dark + bias frame matching.
+**Note**: By default, only exact exposure match darks are copied. Use `--scale-dark` to enable shorter dark + bias frame matching.
 
 ### Flat Frames
 
@@ -92,8 +93,8 @@ python -m ap_copy_master_to_blink <library_dir> <blink_dir> --debug
 # With quiet mode (minimal output)
 python -m ap_copy_master_to_blink <library_dir> <blink_dir> --quiet
 
-# Allow shorter darks with bias frames
-python -m ap_copy_master_to_blink <library_dir> <blink_dir> --allow-bias
+# Enable bias-compensated dark scaling (allows shorter dark exposures)
+python -m ap_copy_master_to_blink <library_dir> <blink_dir> --scale-dark
 
 # Real example
 python -m ap_copy_master_to_blink \
@@ -108,7 +109,7 @@ python -m ap_copy_master_to_blink \
 - `--dryrun`: Show what would be copied without actually copying files
 - `--debug`: Enable debug logging
 - `--quiet`, `-q`: Suppress progress output
-- `--allow-bias`: Allow shorter darks with bias frames (default: only exact exposure match darks)
+- `--scale-dark`: Scale dark frames using bias compensation (allows shorter exposures). Default: exact exposure match only
 
 ## Directory Structure
 

--- a/ap_copy_master_to_blink/__main__.py
+++ b/ap_copy_master_to_blink/__main__.py
@@ -165,10 +165,11 @@ Examples:
     )
 
     parser.add_argument(
-        "--allow-bias",
-        action="store_true",
-        help="Allow shorter darks with bias frames. "
-        "Default: only exact exposure match darks are copied.",
+        "--scale-dark",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="scale dark frames using bias compensation (allows shorter exposures). "
+        "Default: exact exposure match only",
     )
 
     args = parser.parse_args()
@@ -197,7 +198,7 @@ Examples:
         blink_dir,
         dry_run=args.dryrun,
         quiet=args.quiet,
-        allow_bias=args.allow_bias,
+        scale_darks=args.scale_darks,
     )
 
     # Print summary

--- a/ap_copy_master_to_blink/copy_masters.py
+++ b/ap_copy_master_to_blink/copy_masters.py
@@ -231,7 +231,7 @@ def process_blink_directory(
     blink_dir: Path,
     dry_run: bool = False,
     quiet: bool = False,
-    allow_bias: bool = False,
+    scale_darks: bool = False,
 ) -> Dict[str, int]:
     """
     Main orchestration logic to copy masters to blink directories.
@@ -241,8 +241,8 @@ def process_blink_directory(
         blink_dir: Path to blink directory tree
         dry_run: If True, log actions but don't copy files
         quiet: Suppress progress output
-        allow_bias: If False, only exact exposure match darks are copied.
-                   If True, shorter exposure darks with bias are allowed.
+        scale_darks: If False, only exact exposure match darks are copied.
+                    If True, shorter exposure darks with bias are allowed.
 
     Returns:
         Dictionary with summary statistics:
@@ -340,7 +340,7 @@ def process_blink_directory(
 
         # Find required masters
         masters = determine_required_masters(
-            library_dir, light_metadata, allow_bias=allow_bias
+            library_dir, light_metadata, scale_darks=scale_darks
         )
         dark = masters[TYPE_MASTER_DARK]
         bias = masters[TYPE_MASTER_BIAS]

--- a/ap_copy_master_to_blink/matching.py
+++ b/ap_copy_master_to_blink/matching.py
@@ -75,20 +75,20 @@ logger = logging.getLogger(__name__)
 def find_matching_dark(
     library_dir: Path,
     light_metadata: Dict[str, str],
-    allow_bias: bool = False,
+    scale_darks: bool = False,
 ) -> Optional[Dict[str, str]]:
     """
     Find matching dark frame for a light frame.
 
     Priority:
     1. Exact exposure match
-    2. If allow_bias=True and no exact match: longest dark < light
+    2. If scale_darks=True and no exact match: longest dark < light
 
     Args:
         library_dir: Path to calibration library
         light_metadata: Metadata dictionary for light frame
-        allow_bias: If False, only exact exposure match darks are returned.
-                   If True, shorter exposure darks are also allowed.
+        scale_darks: If False, only exact exposure match darks are returned.
+                    If True, shorter exposure darks are also allowed.
 
     Returns:
         Metadata dict for matching dark, or None if no match found
@@ -104,7 +104,7 @@ def find_matching_dark(
             NORMALIZED_HEADER_SETTEMP,
             NORMALIZED_HEADER_READOUTMODE,
         ],
-        allow_shorter_exposure=allow_bias,
+        allow_shorter_exposure=scale_darks,
         recursive=True,
         profileFromPath=False,  # Read file headers, not path structure
         printStatus=False,  # No progress output for library search
@@ -247,7 +247,7 @@ def find_matching_flat(
 def determine_required_masters(
     library_dir: Path,
     light_metadata: Dict[str, str],
-    allow_bias: bool = False,
+    scale_darks: bool = False,
 ) -> Dict[str, Optional[Dict[str, str]]]:
     """
     Determine which master frames are required for a light frame.
@@ -255,8 +255,8 @@ def determine_required_masters(
     Args:
         library_dir: Path to calibration library
         light_metadata: Metadata dictionary for light frame
-        allow_bias: If False, only exact exposure match darks are allowed.
-                   If True, shorter exposure darks with bias are allowed.
+        scale_darks: If False, only exact exposure match darks are allowed.
+                    If True, shorter exposure darks with bias are allowed.
 
     Returns:
         Dictionary with keys:
@@ -266,7 +266,7 @@ def determine_required_masters(
     """
     logger.debug("Determining required masters for light frame")
 
-    dark = find_matching_dark(library_dir, light_metadata, allow_bias=allow_bias)
+    dark = find_matching_dark(library_dir, light_metadata, scale_darks=scale_darks)
     bias = None
     flat = find_matching_flat(library_dir, light_metadata)
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -83,7 +83,7 @@ class TestMatching(unittest.TestCase):
         ]
 
         result = find_matching_dark(
-            self.library_dir, self.light_metadata, allow_bias=True
+            self.library_dir, self.light_metadata, scale_darks=True
         )
 
         self.assertIsNotNone(result)


### PR DESCRIPTION
- Rename CLI flag from --allow-bias to --scale-dark for consistency with singular convention
- Use BooleanOptionalAction for cleaner boolean flag handling
- Rename parameter from allow_bias to scale_darks throughout codebase
- Update help text to be more descriptive of functionality
- Update README and documentation to reflect new flag name

Assisted-by: Claude Code (Claude Sonnet 4.5)